### PR TITLE
Expose parse_single_dep function

### DIFF
--- a/src/package.rs
+++ b/src/package.rs
@@ -485,7 +485,7 @@ impl fmt::Display for Dependency {
 }
 
 /// Parse a single dependency
-fn parse_single_dep(s: &str) -> Result<SingleDependency, &'static str> {
+pub fn parse_single_dep(s: &str) -> Result<SingleDependency, &'static str> {
     enum ST {
         PackageName,
         PreVersion,


### PR DESCRIPTION
Well nothing magic ;) but for my use case it would be practical to be able to parse a single dependency string. Thanks for the crate!