### PR TITLE
Serde support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,3 +21,9 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+      - name: Run cargo test feature serde
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -F serde_support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ tempfile = "3"
 serde = { version = "1.0.147", optional = true, features = [ "derive" ]}
 
 [features]
-default = ["serde_support"]
 serde_support = ["chrono/serde", "serde" ]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,19 @@ interacting with apt.
 repository = "https://github.com/mwanner/rust-debian"
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4" }
 log = "0.4"
 time = "0.3"
 tempfile = "3"
+serde = { version = "1.0.147", optional = true, features = [ "derive" ]}
+
+[features]
+default = ["serde_support"]
+serde_support = ["chrono/serde", "serde" ]
 
 [lib]
 name = "debian"
 path = "src/lib.rs"
+
+[dev-dependencies]
+serde_json = "1.0.89"

--- a/src/package.rs
+++ b/src/package.rs
@@ -16,6 +16,7 @@ use chrono::prelude::*;
 use super::Version;
 
 /// Represents a single entry in a debian/changelog file.
+#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug)]
 pub struct ChangelogEntry {
     /// source package name
@@ -50,6 +51,7 @@ pub struct ChangelogEntry {
 ///
 /// let changelog = Changelog::from_file(Path::new("debian/changelog"));
 /// ```
+#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug)]
 pub struct Changelog {
     entries: Vec<ChangelogEntry>,
@@ -175,6 +177,7 @@ pub fn get_default_maintainer_email() -> String {
 }
 
 /// A value in a field of a control file
+#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone)]
 pub enum ControlValue {
     /// A simple string value
@@ -186,6 +189,7 @@ pub enum ControlValue {
 }
 
 /// A single field or entry in a control file
+#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone)]
 pub struct ControlEntry {
     key: String,
@@ -193,12 +197,14 @@ pub struct ControlEntry {
 }
 
 /// A paragraph consisting of multiple entries of type `ControlEntry`.
+#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone)]
 pub struct ControlParagraph {
     entries: Vec<ControlEntry>,
 }
 
 /// A control file consisting of multiple paragraphs.
+#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug)]
 pub struct ControlFile {
     paragraphs: Vec<ControlParagraph>,

--- a/src/version.rs
+++ b/src/version.rs
@@ -138,6 +138,14 @@ impl Version {
     }
 }
 
+impl FromStr for Version {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Version::parse(s)
+    }
+}
+
 impl Ord for Version {
     fn cmp(&self, other: &Version) -> Ordering {
         let epoch_cmp = self.epoch.cmp(&other.epoch);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -164,3 +164,22 @@ fn dependency_basics() {
         ))
     );
 }
+
+#[cfg(feature = "serde_support")]
+#[test]
+fn serde_tests() {
+    let data = r#"[
+        "8:1.8-0~bpo2",
+        "1.8-0",
+        "1:1:1-8-8"
+    ]"#;
+    let versions: Vec<Version> = serde_json::from_str(data).unwrap();
+    assert_eq!(versions.len(), 3);
+    assert_eq!(versions[0], Version::parse("8:1.8-0~bpo2").unwrap());
+    assert_eq!(versions[1], Version::parse("1.8-0").unwrap());
+    assert_eq!(versions[2], Version::parse("1:1:1-8-8").unwrap());
+
+    // test serialization
+    let ser = serde_json::to_string(&versions).unwrap();
+    assert_eq!(ser, r#"["8:1.8-0~bpo2","1.8-0","1:1:1-8-8"]"#);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,6 +5,7 @@ extern crate tempfile;
 
 use std::env;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use tempfile::TempDir;
 
@@ -77,6 +78,7 @@ fn version_basics() {
     assert_eq!(&v.upstream_version.to_string(), "2.1.4");
     assert_eq!(&v.upstream_version.to_string(), "2.1.4");
     assert_eq!(&v.debian_revision.to_string(), "0~bpo2");
+    assert_eq!(Version::from_str("7:2.1.4-0~bpo2").unwrap(), v);
 
     let v = Version::parse("2.1.4-0~bpo2").unwrap();
     assert_eq!(v.epoch, 0);


### PR DESCRIPTION
This PR adds serde support with the feature flag serde_support.
This allows the data types in this crate to be used in serialize/deserialize structures.
This PR also adds the FromStr impl for more ergonomics.